### PR TITLE
Add a basic python pie chart generator

### DIFF
--- a/panopticon-viz.py
+++ b/panopticon-viz.py
@@ -20,5 +20,5 @@ if __name__ == "__main__":
         title="Panopticon Time Chart",
         template="plotly_dark",
     )
-    fig.update_traces(textposition="inside", textinfo="percent+label")
+    fig.update_traces(textposition="outside", textinfo="percent+label")
     fig.show()

--- a/panopticon-viz.py
+++ b/panopticon-viz.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python3
+import argparse
+
 import pandas as pd
 import plotly.express as px
-import argparse
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -13,7 +14,11 @@ if __name__ == "__main__":
     df = pd.read_csv(args["input-file"])
     df = df[df.activity != "none"]
     fig = px.pie(
-        df, values="milliseconds", names="activity", title="Panopticon Time Chart"
+        df,
+        values="milliseconds",
+        names="activity",
+        title="Panopticon Time Chart",
+        template="plotly_dark",
     )
     fig.update_traces(textposition="inside", textinfo="percent+label")
     fig.show()

--- a/panopticon-viz.py
+++ b/panopticon-viz.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python3
+import pandas as pd
+import plotly.express as px
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "input-file", type=str, help="csv file exported from Panopticon"
+    )
+    args = vars(parser.parse_args())
+
+    df = pd.read_csv(args["input-file"])
+    df = df[df.activity != "none"]
+    fig = px.pie(
+        df, values="milliseconds", names="activity", title="Panopticon Time Chart"
+    )
+    fig.update_traces(textposition="inside", textinfo="percent+label")
+    fig.show()


### PR DESCRIPTION
It would be nice to have a basic tool that would make a pie chart for you.

```sh
$ ./panopticon-viz.py -h
usage: panopticon-viz.py [-h] input-file

positional arguments:
  input-file  csv file exported from Panopticon

optional arguments:
  -h, --help  show this help message and exit
```

![image](https://user-images.githubusercontent.com/3466119/93510308-f5533f80-f8ee-11ea-8064-d69924936002.png)

